### PR TITLE
Update lock strategy

### DIFF
--- a/server.js
+++ b/server.js
@@ -675,7 +675,9 @@
         datasource.lock(
             req.body.id,
             username,
-            req.body.eventKey
+            req.body.eventKey,
+            undefined,
+            false
         ).then(
             respond.bind(res)
         ).catch(

--- a/server/datasource.js
+++ b/server/datasource.js
@@ -461,6 +461,14 @@
     */
     that.lock = function (id, username, eventkey, process, client) {
         return new Promise(function (resolve, reject) {
+            if (client === undefined) {
+                reject(
+                    "No parameter passed for the client argument " +
+                    "on lock attempt. Either a database client or " +
+                    "`false` must be passed"
+                );
+                return;
+            }
             let theClient;
             // Do the work
             function doLock(resp) {


### PR DESCRIPTION
Use advisory locks to enable processes to wait for lock release instead of erroring out or otherwise locking everyone out from reading.